### PR TITLE
Update Next.js configuration and start script

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,11 @@
 import type { NextConfig } from "next";
 
-const isProd = process.env.NODE_ENV === "production";
+// Use NEXT_PUBLIC_BASE_PATH to explicitly set basePath in environments that need it.
+// If not provided, default to empty so local serving of `out` works without subpath.
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 
 const nextConfig: NextConfig = {
-  basePath: isProd ? "/catchcraft" : "",
+  basePath,
   output: "export",
   images: { unoptimized: true },
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "start": "next start",
+    "start": "npx serve@latest out",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
Modify the Next.js configuration to utilize the `NEXT_PUBLIC_BASE_PATH` environment variable for setting the base path, ensuring compatibility with different environments. Change the start script to use `npx serve` for serving the built output.